### PR TITLE
Migrate to UUID types

### DIFF
--- a/src/hooks/use-action-items-data.ts
+++ b/src/hooks/use-action-items-data.ts
@@ -1,22 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+
+type ActionItemInsightResult = Database['public']['Functions']['get_action_items_with_insights']['Returns'][number];
 
 export interface ActionItem {
-  id: number;
+  id: string;
   content: string;
   created_at: string;
-  related_insights?: number[];
+  related_insights?: string[];
   related_insights_data?: {
-    insight_key: number;
+    insight_key: string;
     insight_content: string;
   }[];
-}
-
-interface ActionItemInsightResult {
-  actionitem_key: number;
-  actionitem_content: string;
-  insight_key: number;
-  insight_content: string;
 }
 
 export function useActionItemsData() {
@@ -25,7 +21,8 @@ export function useActionItemsData() {
     
     try {
       const { data, error } = await supabase
-        .rpc<ActionItemInsightResult>('get_action_items_with_insights');
+        .rpc('get_action_items_with_insights')
+        .returns<ActionItemInsightResult[]>();
       
       if (error) {
         console.error('Error fetching action items data:', error);
@@ -38,7 +35,7 @@ export function useActionItemsData() {
       }
 
       // Group the results by action item
-      const actionItemsMap = new Map<number, ActionItem>();
+      const actionItemsMap = new Map<string, ActionItem>();
       
       data.forEach(row => {
         if (!actionItemsMap.has(row.actionitem_key)) {

--- a/src/hooks/use-insights-data.ts
+++ b/src/hooks/use-insights-data.ts
@@ -1,30 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+
+type InsightFeedbackResult = Database['public']['Functions']['get_insights_with_feedbacks']['Returns'][number];
 
 export interface Insight {
-  id: number;
+  id: string;
   content: string;
   created_at: string;
-  related_feedbacks?: number[];
+  related_feedbacks?: string[];
   related_feedbacks_data?: {
-    feedback_key: number;
+    feedback_key: string;
     feedback_content: string;
     source: string;
     segment: string;
     sentiment: string;
     feedback_created_at: string;
   }[];
-}
-
-interface InsightFeedbackResult {
-  insight_key: number;
-  insight_content: string;
-  feedback_key: number;
-  feedback_content: string;
-  source: string;
-  segment: string;
-  sentiment: string;
-  "Creation Date": string;
 }
 
 export function useInsightsData() {
@@ -34,7 +26,8 @@ export function useInsightsData() {
     try {
       // Use the RPC to fetch insights with their related feedbacks
       const { data, error } = await supabase
-        .rpc<InsightFeedbackResult>('get_insights_with_feedbacks');
+        .rpc('get_insights_with_feedbacks')
+        .returns<InsightFeedbackResult[]>();
       
       if (error) {
         console.error('Error fetching insights data:', error);
@@ -47,7 +40,7 @@ export function useInsightsData() {
       }
 
       // Group the results by insight
-      const insightsMap = new Map<number, Insight>();
+      const insightsMap = new Map<string, Insight>();
       
       data.forEach(row => {
         if (!insightsMap.has(row.insight_key)) {
@@ -70,7 +63,7 @@ export function useInsightsData() {
             source: row.source || '',
             segment: row.segment || '',
             sentiment: row.sentiment || '',
-            feedback_created_at: row["Creation Date"] || new Date().toISOString()
+            feedback_created_at: row.feedback_created_at || new Date().toISOString()
           });
         }
       });

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1,6 +1,6 @@
 export type Json =
   | string
-  | number
+  | string
   | boolean
   | null
   | { [key: string]: Json | undefined }
@@ -11,31 +11,31 @@ export type Database = {
     Tables: {
       action_items: {
         Row: {
-          actionitem_key: number
+          actionitem_key: string
           content: string | null
         }
         Insert: {
-          actionitem_key: number
+          actionitem_key: string
           content?: string | null
         }
         Update: {
-          actionitem_key?: number
+          actionitem_key?: string
           content?: string | null
         }
         Relationships: []
       }
       actionitems_insights: {
         Row: {
-          actionitem_key: number
-          insight_key: number
+          actionitem_key: string
+          insight_key: string
         }
         Insert: {
-          actionitem_key: number
-          insight_key: number
+          actionitem_key: string
+          insight_key: string
         }
         Update: {
-          actionitem_key?: number
-          insight_key?: number
+          actionitem_key?: string
+          insight_key?: string
         }
         Relationships: [
           {
@@ -56,16 +56,16 @@ export type Database = {
       }
       actionitems_labels: {
         Row: {
-          actionitem_key: number
-          label_key: number
+          actionitem_key: string
+          label_key: string
         }
         Insert: {
-          actionitem_key: number
-          label_key: number
+          actionitem_key: string
+          label_key: string
         }
         Update: {
-          actionitem_key?: number
-          label_key?: number
+          actionitem_key?: string
+          label_key?: string
         }
         Relationships: [
           {
@@ -88,8 +88,8 @@ export type Database = {
         Row: {
           content: string | null
           "Creation Date": string | null
-          customer_id: number | null
-          feedback_key: number
+          customer_id: string | null
+          feedback_key: string
           segment: string | null
           sentiment: string | null
           source: string | null
@@ -97,8 +97,8 @@ export type Database = {
         Insert: {
           content?: string | null
           "Creation Date"?: string | null
-          customer_id?: number | null
-          feedback_key: number
+          customer_id?: string | null
+          feedback_key: string
           segment?: string | null
           sentiment?: string | null
           source?: string | null
@@ -106,8 +106,8 @@ export type Database = {
         Update: {
           content?: string | null
           "Creation Date"?: string | null
-          customer_id?: number | null
-          feedback_key?: number
+          customer_id?: string | null
+          feedback_key?: string
           segment?: string | null
           sentiment?: string | null
           source?: string | null
@@ -116,16 +116,16 @@ export type Database = {
       }
       insight_labels: {
         Row: {
-          insight_key: number
-          label_key: number
+          insight_key: string
+          label_key: string
         }
         Insert: {
-          insight_key: number
-          label_key: number
+          insight_key: string
+          label_key: string
         }
         Update: {
-          insight_key?: number
-          label_key?: number
+          insight_key?: string
+          label_key?: string
         }
         Relationships: [
           {
@@ -147,30 +147,30 @@ export type Database = {
       insights: {
         Row: {
           content: string | null
-          insight_key: number
+          insight_key: string
         }
         Insert: {
           content?: string | null
-          insight_key: number
+          insight_key: string
         }
         Update: {
           content?: string | null
-          insight_key?: number
+          insight_key?: string
         }
         Relationships: []
       }
       insights_feedbacks: {
         Row: {
-          feedback_key: number
-          insight_key: number
+          feedback_key: string
+          insight_key: string
         }
         Insert: {
-          feedback_key: number
-          insight_key: number
+          feedback_key: string
+          insight_key: string
         }
         Update: {
-          feedback_key?: number
-          insight_key?: number
+          feedback_key?: string
+          insight_key?: string
         }
         Relationships: [
           {
@@ -192,15 +192,15 @@ export type Database = {
       labels: {
         Row: {
           label: string | null
-          label_key: number
+          label_key: string
         }
         Insert: {
           label?: string | null
-          label_key: number
+          label_key: string
         }
         Update: {
           label?: string | null
-          label_key?: number
+          label_key?: string
         }
         Relationships: []
       }
@@ -209,7 +209,28 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      get_insights_with_feedbacks: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          insight_key: string
+          insight_content: string
+          feedback_key: string
+          feedback_content: string
+          source: string
+          segment: string
+          sentiment: string
+          feedback_created_at: string
+        }[]
+      }
+      get_action_items_with_insights: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          actionitem_key: string
+          actionitem_content: string
+          insight_key: string
+          insight_content: string
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
Changes made:
- Updated database types in types.ts to use string (UUID) instead of integers
- Added RPC function definitions with proper return types
- Updated use-insights-data.ts:
  * Changed all key fields from number to string
  * Updated RPC call to use proper type definitions
  * Fixed feedback_created_at field name
- Updated use-action-items-data.ts:
  * Changed all key fields from number to string
  * Updated RPC call to use proper type definitions
- Updated interfaces to handle UUID types consistently